### PR TITLE
Switch to Buildah for building images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,17 +75,27 @@ jobs:
       with:
         go-version: '1.21'
 
-    - name: Build and push Docker image with Kaniko
-      uses: aevea/action-kaniko@master
+    - name: Build image with Buildah
+      id: build-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        context: .
+        containerfiles: ./Dockerfile
+        image: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: ${{ github.sha }} latest
+
+    - name: Log in to Harbor registry
+      uses: redhat-actions/podman-login@v1
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ secrets.HARBOR_USERNAME }}
         password: ${{ secrets.HARBOR_PASSWORD }}
-        image: ${{ env.IMAGE_NAME }}
-        tag: ${{ github.sha }}
-        tag_with_latest: true
-        cache: true
-        cache_registry: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/cache
+
+    - name: Push image to registry
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-image.outputs.image }}
+        tags: ${{ steps.build-image.outputs.tags }}
 
   security-scan:
     runs-on: otel-pod-mutation-set

--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ For local development:
 docker build -t harbor.rackspace.koski.co/library/otel-pod-mutation:latest .
 ```
 
-For Kubernetes environments (self-hosted runners), the CI/CD pipeline uses Kaniko to build images without requiring Docker daemon access.
+For Kubernetes environments (self-hosted runners), the CI/CD pipeline uses Buildah to build images without requiring a Docker daemon.
 
 ## GitHub Actions
 
 The project includes a CI/CD pipeline that:
 
 1. Runs tests and code quality checks
-2. Builds and pushes Docker images to Harbor registry using Kaniko (compatible with Kubernetes runners)
+2. Builds and pushes Docker images to Harbor registry using Buildah and Podman (compatible with Kubernetes runners)
 3. Runs security scans with Trivy
 
 Required secrets:


### PR DESCRIPTION
## Summary
- replace Kaniko with Buildah and Podman actions in CI
- document Buildah usage in README

## Testing
- `go test ./...`
- `python -c "import yaml,sys;yaml.safe_load(open('.github/workflows/ci.yaml'));print('ok')"`


------
https://chatgpt.com/codex/tasks/task_e_6845ab23c588832689555fa3f7ddc464