### PR TITLE
Enable manual workflow dispatch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 env:
   REGISTRY: harbor.rackspace.koski.co


### PR DESCRIPTION
## Summary
- enable manual workflow dispatch by adding `workflow_dispatch` trigger

## Testing
- `go test ./...`
- `act workflow_dispatch -P otel-pod-mutation-set=ghcr.io/catthehacker/ubuntu:act-latest -n` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6845cdffabd48326b8e7efa0414b4be2