### PR TITLE
Switch to Kaniko for container build

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,8 @@
       "Bash(go build:*)",
       "Bash(go test:*)",
       "Bash(go vet:*)",
-      "Bash(gofmt:*)"
+      "Bash(gofmt:*)",
+      "WebFetch(domain:github.com)"
     ],
     "deny": []
   }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,15 +76,25 @@ jobs:
       with:
         go-version: '1.21'
 
-    - name: Build and push image with Kaniko
-      uses: aevea/action-kaniko@v0.14.0
-      with:
-        registry: ${{ env.REGISTRY }}
-        image: ${{ env.IMAGE_NAME }}
-        username: ${{ secrets.HARBOR_USERNAME }}
-        password: ${{ secrets.HARBOR_PASSWORD }}
-        tag: ${{ github.sha }}
-        tag_with_latest: true
+    - name: Set up containerd
+      uses: crazy-max/ghaction-setup-containerd@v3
+
+    - name: Build and push image with Kaniko using containerd
+      run: |
+        mkdir -p "$HOME/.docker"
+        auth=$(printf "%s:%s" "${{ secrets.HARBOR_USERNAME }}" "${{ secrets.HARBOR_PASSWORD }}" | base64)
+        cat > "$HOME/.docker/config.json" <<EOF
+        {"auths": {"${{ env.REGISTRY }}": {"auth": "$auth"}}}
+        EOF
+        sudo ctr image pull gcr.io/kaniko-project/executor:latest
+        sudo ctr run --rm --net-host \
+          -v "$(pwd)":/workspace \
+          -v "$HOME/.docker":/kaniko/.docker \
+          gcr.io/kaniko-project/executor:latest kaniko \
+          --context=dir:///workspace \
+          --dockerfile=/workspace/Dockerfile \
+          --destination=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+          --destination=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
   security-scan:
     runs-on: otel-pod-mutation-set

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,8 +86,8 @@ jobs:
         cat > "$HOME/.docker/config.json" <<EOF
         {"auths": {"${{ env.REGISTRY }}": {"auth": "$auth"}}}
         EOF
-        sudo ctr image pull gcr.io/kaniko-project/executor:latest
-        sudo ctr run --rm --net-host \
+        CONTAINERD_SNAPSHOTTER=native sudo ctr image pull gcr.io/kaniko-project/executor:latest
+        CONTAINERD_SNAPSHOTTER=native sudo ctr run --rm --net-host \
           -v "$(pwd)":/workspace \
           -v "$HOME/.docker":/kaniko/.docker \
           gcr.io/kaniko-project/executor:latest kaniko \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,6 +86,7 @@ jobs:
         buildah login -u "${{ secrets.HARBOR_USERNAME }}" -p "${{ secrets.HARBOR_PASSWORD }}" ${{ env.REGISTRY }}
         
         buildah build \
+          --isolation chroot \
           --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
           --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
           .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
   build-and-push:
     runs-on: otel-pod-mutation-set
     needs: test
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Build and push image with Buildah
       run: |
-        buildah login -u "${{ secrets.HARBOR_USERNAME }}" -p "${{ secrets.HARBOR_PASSWORD }}" ${{ env.REGISTRY }}/v2/
+        buildah login -u "${{ secrets.HARBOR_USERNAME }}" -p "${{ secrets.HARBOR_PASSWORD }}" ${{ env.REGISTRY }}
         
         buildah build \
           --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,19 +76,15 @@ jobs:
       with:
         go-version: '1.21'
 
-    - name: Log in to registry
-      run: |
-        buildah login -u "${{ secrets.HARBOR_USERNAME }}" -p "${{ secrets.HARBOR_PASSWORD }}" ${{ env.REGISTRY }}
-
-    - name: Build image with Buildah
-      run: |
-        buildah bud --format docker -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} .
-
-    - name: Push image to registry
-      run: |
-        buildah push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
-        buildah tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-        buildah push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+    - name: Build and push image with Kaniko
+      uses: aevea/action-kaniko@v0.14.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        image: ${{ env.IMAGE_NAME }}
+        username: ${{ secrets.HARBOR_USERNAME }}
+        password: ${{ secrets.HARBOR_PASSWORD }}
+        tag: ${{ github.sha }}
+        tag_with_latest: true
 
   security-scan:
     runs-on: otel-pod-mutation-set

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,16 +83,21 @@ jobs:
 
     - name: Build and push image with Buildah
       run: |
+        # Configure buildah for privileged container environment
+        export BUILDAH_ISOLATION=chroot
+        export STORAGE_DRIVER=vfs
+        
         buildah login -u "${{ secrets.HARBOR_USERNAME }}" -p "${{ secrets.HARBOR_PASSWORD }}" ${{ env.REGISTRY }}
         
         buildah build \
+          --storage-driver vfs \
           --isolation chroot \
           --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
           --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
           .
         
-        buildah push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
-        buildah push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+        buildah push --storage-driver vfs ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+        buildah push --storage-driver vfs ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
   security-scan:
     runs-on: otel-pod-mutation-set

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
 
     - name: Build and push image with Buildah
       run: |
-        buildah login -u "${{ secrets.HARBOR_USERNAME }}" -p "${{ secrets.HARBOR_PASSWORD }}" ${{ env.REGISTRY }}
+        buildah login -u "${{ secrets.HARBOR_USERNAME }}" -p "${{ secrets.HARBOR_PASSWORD }}" ${{ env.REGISTRY }}/v2/
         
         buildah build \
           --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,25 +76,22 @@ jobs:
       with:
         go-version: '1.21'
 
-    - name: Set up containerd
-      uses: crazy-max/ghaction-setup-containerd@v3
-
-    - name: Build and push image with Kaniko using containerd
+    - name: Install Buildah
       run: |
-        mkdir -p "$HOME/.docker"
-        auth=$(printf "%s:%s" "${{ secrets.HARBOR_USERNAME }}" "${{ secrets.HARBOR_PASSWORD }}" | base64)
-        cat > "$HOME/.docker/config.json" <<EOF
-        {"auths": {"${{ env.REGISTRY }}": {"auth": "$auth"}}}
-        EOF
-        CONTAINERD_SNAPSHOTTER=native sudo ctr image pull gcr.io/kaniko-project/executor:latest
-        CONTAINERD_SNAPSHOTTER=native sudo ctr run --rm --net-host \
-          -v "$(pwd)":/workspace \
-          -v "$HOME/.docker":/kaniko/.docker \
-          gcr.io/kaniko-project/executor:latest kaniko \
-          --context=dir:///workspace \
-          --dockerfile=/workspace/Dockerfile \
-          --destination=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
-          --destination=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+        sudo apt-get update
+        sudo apt-get install -y buildah
+
+    - name: Build and push image with Buildah
+      run: |
+        buildah login -u "${{ secrets.HARBOR_USERNAME }}" -p "${{ secrets.HARBOR_PASSWORD }}" ${{ env.REGISTRY }}
+        
+        buildah build \
+          --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
+          --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
+          .
+        
+        buildah push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+        buildah push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
 
   security-scan:
     runs-on: otel-pod-mutation-set

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS builder
+FROM docker.io/library/golang:1.21-alpine AS builder
 
 WORKDIR /app
 
@@ -9,7 +9,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o webhook .
 
-FROM alpine:latest
+FROM docker.io/library/alpine:latest
 
 RUN apk --no-cache add ca-certificates
 

--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ For local development:
 docker build -t harbor.rackspace.koski.co/library/otel-pod-mutation:latest .
 ```
 
-For Kubernetes environments (self-hosted runners), the CI/CD pipeline uses **Kaniko** running on **containerd** to build container images without needing a Docker daemon.
+For Kubernetes environments (self-hosted runners), the CI/CD pipeline uses **Kaniko** running on **containerd** to build container images without needing a Docker daemon. The workflow pulls and runs Kaniko with the `native` snapshotter so it can operate in an unprivileged environment.
 
 ## GitHub Actions
 
 The project includes a CI/CD pipeline that:
 
 1. Runs tests and code quality checks
-2. Builds and pushes Docker images to Harbor registry using Kaniko with containerd (compatible with ARC Kubernetes runners)
+2. Builds and pushes Docker images to Harbor registry using Kaniko with containerd's `native` snapshotter (compatible with ARC Kubernetes runners)
 3. Runs security scans with Trivy
 
 Required secrets:

--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ For local development:
 docker build -t harbor.rackspace.koski.co/library/otel-pod-mutation:latest .
 ```
 
-For Kubernetes environments (self-hosted runners), the CI/CD pipeline uses **Buildah** to build container images without needing a Docker daemon. This works well in privileged containers.
+For Kubernetes environments (self-hosted runners), the CI/CD pipeline uses **Kaniko** running on **containerd** to build container images without needing a Docker daemon.
 
 ## GitHub Actions
 
 The project includes a CI/CD pipeline that:
 
 1. Runs tests and code quality checks
-2. Builds and pushes Docker images to Harbor registry using Buildah (compatible with ARC Kubernetes runners)
+2. Builds and pushes Docker images to Harbor registry using Kaniko with containerd (compatible with ARC Kubernetes runners)
 3. Runs security scans with Trivy
 
 Required secrets:

--- a/deploy/webhook.yaml
+++ b/deploy/webhook.yaml
@@ -1,5 +1,5 @@
 apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingAdmissionWebhook
+kind: MutatingAdmissionWebhookConfiguration
 metadata:
   name: otel-pod-mutation-webhook
   annotations:


### PR DESCRIPTION
## Summary
- move to `aevea/action-kaniko` for container build and push

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6846280df9908326bac589f44e04eac1